### PR TITLE
Remove check for star mask in remove_stars_with_sextractor.py3

### DIFF
--- a/scripts/ArcPNGcreator/star_removal/remove_stars_with_sextractor.py3
+++ b/scripts/ArcPNGcreator/star_removal/remove_stars_with_sextractor.py3
@@ -536,12 +536,12 @@ if __name__ == '__main__':
                 
                 logger.info("wrote {0}".format(out_filepath))
             
-            # Sparcfire produces an error when there's no star_mask values and does not proceed
-            # I believe that is an error but for now, take this as a temporary fix
-            if np.any(star_mask):
+            # Now that levels are properly working, produce a png
+            # regardless of star mask.
+            #if np.any(star_mask):
                 #iio.imwrite(os.path.join(out_dirpath, in_imgname + '_starmask.png'), mask_levels, mode = "L")
-                image = Image.fromarray(np.uint8(mask_levels), mode = "L")
-                image.save(os.path.join(out_dirpath, in_imgname + '_starmask.png'))
+            image = Image.fromarray(np.uint8(mask_levels), mode = "L")
+            image.save(os.path.join(out_dirpath, in_imgname + '_starmask.png'))
                 
             # if np.any(star_mask_aggressive):
             #     iio.imwrite(os.path.join(out_dirpath, in_imgname + '_starmask_aggressive.png'), mask_levels, mode = "LA")

--- a/star_removal/remove_stars_with_sextractor.py3
+++ b/star_removal/remove_stars_with_sextractor.py3
@@ -536,12 +536,12 @@ if __name__ == '__main__':
                 
                 logger.info("wrote {0}".format(out_filepath))
             
-            # Sparcfire produces an error when there's no star_mask values and does not proceed
-            # I believe that is an error but for now, take this as a temporary fix
-            if np.any(star_mask):
+            # Now that levels are properly working, produce a png
+            # regardless of star mask.
+            #if np.any(star_mask):
                 #iio.imwrite(os.path.join(out_dirpath, in_imgname + '_starmask.png'), mask_levels, mode = "L")
-                image = Image.fromarray(np.uint8(mask_levels), mode = "L")
-                image.save(os.path.join(out_dirpath, in_imgname + '_starmask.png'))
+            image = Image.fromarray(np.uint8(mask_levels), mode = "L")
+            image.save(os.path.join(out_dirpath, in_imgname + '_starmask.png'))
                 
             # if np.any(star_mask_aggressive):
             #     iio.imwrite(os.path.join(out_dirpath, in_imgname + '_starmask_aggressive.png'), mask_levels, mode = "LA")


### PR DESCRIPTION
This allows the python3 version of the script to work like the python2 version, i.e. it outputs the 'starmask' image with different 'mask' levels regardless if a mask was created by source extractor.  

The previous code may still have passed the reg tests depending on how Sparcfire uses the alternative mask levels... if at all. By which I mean to say that, no reg testing protocols were bypassed in the making of this mistake ;) 